### PR TITLE
fix(publish): 补齐 bundle 发布规范 — types/peerDependencies/prepack + files 含 src

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,24 +13,37 @@
   },
   "type": "module",
   "main": "lib/index.js",
+  "types": "lib/types/index.d.ts",
   "exports": {
-    ".": "./lib/index.js",
-    "./client": "./lib/client.js",
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./client": {
+      "types": "./lib/types/client/index.d.ts",
+      "default": "./lib/client.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
     "lib",
+    "src",
     "cordis.patch.yml",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
     "build": "node scripts/build.mjs",
+    "build:types": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
+    "prepack": "npm run typecheck && npm run build && npm run build:types",
     "test": "npm run typecheck && node tests/host.test.mjs && node tests/client.test.mjs",
     "release": "bash scripts/publish.sh",
     "prepare": "husky",
     "repro": "node tests/repro-real-react.mjs"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1"
   },
   "dsh": {
     "bundle": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -4,7 +4,8 @@
  * schema; every `@deepseek-ai/*` contract is type-only and erased here).
  *
  * Produces the npm-package artifacts under lib/:
- *   lib/index.js  — host half: src/host/ bundled to plain ESM (zod external).
+ *   lib/index.js  — host half: src/index.ts (re-export of src/host/) bundled
+ *                   to plain ESM (zod external).
  *   lib/client.js — client half: src/client/ bundled to CJS, then
  *                   wrapped in the web boot handoff
  *                   `window.__ModuleLoader__.load({ id, factory })`, the
@@ -22,7 +23,7 @@
 import { build } from 'esbuild'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const pkg = JSON.parse(await readFile(join(ROOT, 'package.json'), 'utf8'))
@@ -33,7 +34,7 @@ await mkdir(join(ROOT, 'lib'), { recursive: true })
 // provides the wire schema validator, like every other @deepseek-ai/* runtime
 // service; the package ships zod as a regular dependency) ----------------
 await build({
-  entryPoints: [join(ROOT, 'src', 'host', 'index.ts')],
+  entryPoints: [join(ROOT, 'src', 'index.ts')],
   outfile: join(ROOT, 'lib', 'index.js'),
   format: 'esm',
   platform: 'node',
@@ -79,7 +80,7 @@ await writeFile(join(ROOT, 'lib', 'client.js'), bundle)
 
 // ---- smoke checks ----
 new Function(bundle) // syntax parse only; never executes (window is undefined here)
-const host = await import(join(ROOT, 'lib', 'index.js'))
+const host = await import(pathToFileURL(join(ROOT, 'lib', 'index.js')).href)
 if (host.name !== 'dsh-context' || !Array.isArray(host.inject) || typeof host.apply !== 'function') {
   throw new Error('host half does not expose the expected plugin shape (name/inject/apply)')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * dsh-context — canonical package entry (host half).
+ *
+ * The npm-package main entry (`lib/index.js`) is bundled from this file by
+ * `scripts/build.mjs`; the harness loads it as the `dsh-context` loader row.
+ * All value/type exports live in the host module — this file only re-exports
+ * them so the source tree keeps the conventional `src/index.ts` entry shape.
+ */
+
+export * from './host/index'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "lib/types"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}


### PR DESCRIPTION
Closes #1

## 背景
issue #1 中 `plugin_check`（DSH 内置工具）对本包做 bundle 体检，发现发布规范问题：`types` 未声明、`src/index.ts` 缺失、`files` 缺 `src`、`peerDependencies` 未声明、缺 `prepack` 脚本。本 PR 逐一补齐，并在 Windows 上实测验证。

## 改动
- **package.json**：声明 `types`（`lib/types/index.d.ts`）；`exports` 改为条件导出（`types` / `default`），`.`, `./client` 均带类型入口
- **package.json**：新增 `peerDependencies` 声明 `@deepseek-ai/cordis ^4.0.1`（与 devDependencies 一致；host 半 `import type { Context } from '@deepseek-ai/cordis'`）
- **package.json**：新增 `scripts.prepack`（`typecheck && build && build:types`），发布 tarball 必含 `lib/`
- **package.json**：`files` 补 `src`
- **src/index.ts**（新增）：规范入口，重新导出 host 半；构建入口同步切换（`scripts/build.mjs`）
- **tsconfig.build.json**（新增）：`tsc --emitDeclarationOnly` 生成声明到 `lib/types/`
- **scripts/build.mjs**：冒烟检查的 `import()` 改用 `pathToFileURL`，修复 Windows 下 `ERR_UNSUPPORTED_ESM_URL_SCHEME`（构建无法在 Windows 复现的问题，与本次发布规范相关）

## 验证（Windows / Node 24 / pnpm，clean checkout）
- `npm run typecheck` ✅
- `npm run build` ✅（host/client 两半 + 冒烟检查通过）
- `npm run build:types` ✅（生成 `lib/types/**` 完整声明树）
- `npm test` ✅（typecheck + host 功能测试 + client bundle 测试 + chart 渲染测试）
- `npm pack --dry-run` ✅（tarball 49 个文件，含 `lib/index.js`、`lib/client.js`、`lib/types/**`、`src/**`）
- `plugin_check check` 复检：**verdict: pass**（19 项检查 18 通过 0 失败 0 警告，1 项 skip 为 hub catalog 网络探测，与仓库无关）

## 说明
- `lib/` 为构建产物（`.gitignore` 已排除），由 `prepack` 在发布时生成；因此 `plugin_check` 的 "main 文件不存在" 仅在构建后消失，属预期行为
- 未 bump 版本号：`scripts/publish.sh` 发布时会自动 bump patch
