### PR TITLE
fix(host): keep timeline state plain JSON for the projection cache

### DIFF
--- a/src/host/fold.ts
+++ b/src/host/fold.ts
@@ -444,8 +444,6 @@ export function applyTimeline(state: TimelineState, event: TimelineEvent, bounds
       const s = ensure()
       const total = s.systemTokens + s.toolsTokens + s.sums.user + s.sums.inject + s.sums.assistant + s.sums.tool
       const record: RequestRecord = {
-        turn: data && typeof data.turn === 'number' ? data.turn : undefined,
-        step: data && typeof data.step === 'number' ? data.step : undefined,
         time: event.time, seq: event.seq,
         system: s.systemTokens,
         tools: s.toolsTokens,
@@ -455,6 +453,12 @@ export function applyTimeline(state: TimelineState, event: TimelineEvent, bounds
         tool: s.sums.tool,
         total,
       }
+      // `turn`/`step` are optional in the durable vocabulary (and on replay);
+      // write them only on a real number so an absent value never materializes
+      // an `undefined` property (plain-JSON persisted-state precondition — see
+      // TimelineState) — the same trap that broke the projection cache here.
+      if (data && typeof data.turn === 'number') record.turn = data.turn
+      if (data && typeof data.step === 'number') record.step = data.step
       if (usage && typeof usage.inputTokens === 'number') {
         // Official TokenUsage semantics (dsh-llm): the buckets are disjoint —
         // inputTokens is uncached input only, cache read/write are separate,

--- a/src/host/fold.ts
+++ b/src/host/fold.ts
@@ -69,10 +69,20 @@ export interface TimelineState {
   systemTokens: number
   toolsTokens: number
   toolList: { name: string; tokens: number }[]
-  model: string | undefined
-  provider: string | undefined
-  lastModel: string | undefined
-  contextWindow: number | undefined
+  /**
+   * The projection-cache precondition is plain JSON: a property whose value
+   * is `undefined` makes the whole checkpoint unserializable
+   * (`snapshotJsonValue` rejects it), which fails EVERY cache write for the
+   * session — including the `title` projection row that powers the session
+   * list after a restart. Optional fields therefore use absent properties
+   * (`model`/`provider`/`lastModel`/`contextWindow` are simply not set until
+   * a value is known) instead of `undefined`-valued ones. Reads via
+   * `state.model` are identical for both shapes (`undefined` on miss).
+   */
+  model?: string
+  provider?: string
+  lastModel?: string
+  contextWindow?: number
   requests: RequestRecord[]
   events: ContextEventRecord[]
   /**
@@ -93,6 +103,8 @@ export interface TimelineState {
    * producer's shadow price covers exactly these seqs — which can differ
    * from the replacement's declared range (pruned replacement nodes keep
    * their own seqs, beyond the range end) — so removal must follow the seqs.
+   * Absent until armed, and REMOVED (not set to `undefined`) when consumed,
+   * to keep the state plain JSON for the projection cache.
    */
   pendingShadowedSeqs?: number[]
 }
@@ -173,10 +185,6 @@ export function createTimelineState(): TimelineState {
     systemTokens: 0,
     toolsTokens: 0,
     toolList: [],
-    model: undefined,
-    provider: undefined,
-    lastModel: undefined,
-    contextWindow: undefined,
     requests: [],
     events: [],
     archived: [],
@@ -268,8 +276,12 @@ function applySurface(
   // The metering event armed the shadowed seqs for the replacement that must
   // follow it synchronously; consume them here (any later surface event
   // would expire them, mirroring the official shadow-price protocol).
+  // DELETE the armed field — assigning `undefined` would leave an
+  // `undefined`-valued property behind, which violates the plain-JSON
+  // persisted-state precondition (see TimelineState) and would fail the
+  // whole session's projection-cache write.
   const shadowedSeqs = st.pendingShadowedSeqs
-  st.pendingShadowedSeqs = undefined
+  delete st.pendingShadowedSeqs
 
   const op = ev.surfaceOp as { op?: string; start?: number; end?: number } | null | undefined
   if (op !== null && typeof op === 'object' && op.op === 'replace') {
@@ -360,6 +372,9 @@ export function applyTimeline(state: TimelineState, event: TimelineEvent, bounds
       // Current route/model: the durable request envelope is the source of
       // truth (request/context is only route/capacity metadata, appended
       // AFTER request/header per request — see agent-loop buildRequestHeader).
+      // Optional fields are set via conditional spread so a still-unknown
+      // value never materializes an `undefined` property (plain-JSON state
+      // precondition — see TimelineState).
       if (header.config && typeof header.config.model === 'string') s.model = header.config.model
       if (header.config && typeof header.config.provider === 'string') s.provider = header.config.provider
       // A model switch has no dedicated durable event: it is a request
@@ -377,7 +392,9 @@ export function applyTimeline(state: TimelineState, event: TimelineEvent, bounds
       // Route/capacity metadata: request/context is logged only when the
       // route or capacity changes (appended after request/header), so it
       // updates the CURRENT route display — it never fires a model-switch
-      // event on its own (see the request/header case).
+      // event on its own (see the request/header case). All three fields
+      // are only written on a real value (plain-JSON state — see
+      // TimelineState), so no `undefined` property can materialize here.
       if (data && typeof data.contextWindow === 'number') s.contextWindow = data.contextWindow
       if (data && typeof data.model === 'string') s.model = data.model
       if (data && typeof data.provider === 'string') s.provider = data.provider

--- a/src/host/timeline.ts
+++ b/src/host/timeline.ts
@@ -126,6 +126,14 @@ export function createContextTimelineDefinition(config: Config): ProjectionDefin
     // 3 since 0.12: the removed-node archive (`archived` + `archiveFloor`)
     // joined the persisted state for the Context browser's per-step
     // reconstruction — cached rows predate the shape and are refolded.
-    stateVersion: 3,
+    // 4 since 0.18: the persisted state no longer carries `undefined`-valued
+    // properties (model/provider/lastModel/contextWindow are absent until
+    // known; pendingShadowedSeqs is deleted when consumed). The previous
+    // shape violated the plain-JSON persisted-state precondition and failed
+    // EVERY session-projection-cache write (TypeError: projection checkpoint
+    // is not losslessly JSON-serializable) — which also starved the `title`
+    // projection row and broke the session list after a restart. The bump
+    // discards old cached rows and refolds them clean.
+    stateVersion: 4,
   }
 }

--- a/tests/host.test.mjs
+++ b/tests/host.test.mjs
@@ -13,6 +13,7 @@
  */
 import assert from 'node:assert/strict'
 import { apply } from '../lib/index.js'
+import { snapshotJsonValue } from '@deepseek-ai/dsh-session'
 
 const defs = new Map()
 const disposers = []
@@ -365,51 +366,30 @@ assert.equal(usageLog.requests[0].output, 30, 'output is outputTokens (reasoning
 
 // -- plain-JSON persisted state (R7): the projection-cache precondition.
 // Every `apply` result must survive the harness's lossless-JSON snapshotter;
-// an `undefined`-valued property would fail the WHOLE session's cache write
-// (TypeError: projection checkpoint is not losslessly JSON-serializable),
-// which also starves the `title` projection row and breaks the session list
-// after a restart. Fold a log that arms AND consumes pendingShadowedSeqs and
-// leaves model/provider/contextWindow unknown at some point, then check every
-// intermediate state through the real snapshotter.
+// an `undefined`-valued property ANYWHERE in the unit state rejects the whole
+// session's checkpoint write (TypeError: projection checkpoint is not
+// losslessly JSON-serializable), starving unrelated rows — including the
+// `title` projection that powers the session list after a restart. Fold the
+// live log (arm-then-consumed shadowed seqs included — live.events arms at
+// seq 10 and consumes via the seq 11 surface event) PLUS one
+// `assistant/message` whose data intentionally LACKS numeric turn/step (they
+// are optional in the durable vocabulary), so no tolerated-absence branch can
+// ever leave an `undefined`-valued property behind. Check every intermediate
+// state through the REAL harness snapshotter.
+const jsonLog = [...live.events, { seq: 99, type: 'assistant/message', time: 9999, data: { message: { content: [{ type: 'text', text: 'no turn/step here' }] } } }]
 const jsonStates = []
 let jsonSt = def.init()
-for (const ev of live.events) {
+for (const ev of jsonLog) {
   jsonSt = def.apply(jsonSt, ev)
   jsonStates.push(jsonSt)
-}
-const snapshotJsonValue = (value) => {
-  // Minimal mirror of the harness snapshotter contract used by
-  // dsh-session-projection-cache.put(): reject undefined values, non-finite
-  // numbers, and non-plain objects; return the detached clone on success.
-  const plain = (v, seen) => {
-    if (v === null || typeof v === 'boolean' || typeof v === 'string') return v
-    if (typeof v === 'number') return Number.isFinite(v) && !Object.is(v, -0) ? v : undefined
-    if (typeof v !== 'object' || seen.has(v)) return undefined
-    seen.add(v)
-    if (Array.isArray(v)) {
-      const proto = Object.getPrototypeOf(v)
-      if (proto !== Array.prototype && proto !== null) return undefined
-      return v.map(item => plain(item, seen))
-    }
-    const proto = Object.getPrototypeOf(v)
-    if (proto !== Object.prototype && proto !== null) return undefined
-    const out = {}
-    for (const key of Object.keys(v)) {
-      const item = plain(v[key], seen)
-      if (item === undefined && v[key] !== null) return undefined
-      out[key] = item
-    }
-    return out
-  }
-  return plain(value, new Set())
 }
 for (const [i, st] of jsonStates.entries()) {
   const cloned = snapshotJsonValue(st)
   assert.ok(cloned !== undefined, `state after event ${i + 1} is losslessly JSON-serializable (plain-JSON projection-cache precondition)`)
   assert.deepEqual(cloned, JSON.parse(JSON.stringify(st)), `state after event ${i + 1} round-trips losslessly`)
 }
-// And the armed-but-unconsumed intermediate (compaction arm then replacement)
-// must also stay serializable.
+// And the armed-but-unconsumed intermediate (compaction arm alone) must also
+// stay serializable.
 const armed = def.apply(def.init(), { seq: 1, type: 'compaction/summary', time: 1000, data: { shadowedSeqs: [2], shadowedTokenCount: 10 } })
 assert.ok(snapshotJsonValue(armed) !== undefined, 'armed pendingShadowedSeqs state is still plain JSON')
 

--- a/tests/host.test.mjs
+++ b/tests/host.test.mjs
@@ -363,4 +363,54 @@ const usageLog = drive([
 assert.equal(usageLog.requests[0].prompt, 1000, 'prompt side sums the disjoint input buckets')
 assert.equal(usageLog.requests[0].output, 30, 'output is outputTokens (reasoning already inside)')
 
-console.log('✔ host half functional test passed (projection unit, fold semantics, attribution, retention, shadow-price seqs, reference stability, determinism, config bounds, inject pinning, model switch, usage mapping)')
+// -- plain-JSON persisted state (R7): the projection-cache precondition.
+// Every `apply` result must survive the harness's lossless-JSON snapshotter;
+// an `undefined`-valued property would fail the WHOLE session's cache write
+// (TypeError: projection checkpoint is not losslessly JSON-serializable),
+// which also starves the `title` projection row and breaks the session list
+// after a restart. Fold a log that arms AND consumes pendingShadowedSeqs and
+// leaves model/provider/contextWindow unknown at some point, then check every
+// intermediate state through the real snapshotter.
+const jsonStates = []
+let jsonSt = def.init()
+for (const ev of live.events) {
+  jsonSt = def.apply(jsonSt, ev)
+  jsonStates.push(jsonSt)
+}
+const snapshotJsonValue = (value) => {
+  // Minimal mirror of the harness snapshotter contract used by
+  // dsh-session-projection-cache.put(): reject undefined values, non-finite
+  // numbers, and non-plain objects; return the detached clone on success.
+  const plain = (v, seen) => {
+    if (v === null || typeof v === 'boolean' || typeof v === 'string') return v
+    if (typeof v === 'number') return Number.isFinite(v) && !Object.is(v, -0) ? v : undefined
+    if (typeof v !== 'object' || seen.has(v)) return undefined
+    seen.add(v)
+    if (Array.isArray(v)) {
+      const proto = Object.getPrototypeOf(v)
+      if (proto !== Array.prototype && proto !== null) return undefined
+      return v.map(item => plain(item, seen))
+    }
+    const proto = Object.getPrototypeOf(v)
+    if (proto !== Object.prototype && proto !== null) return undefined
+    const out = {}
+    for (const key of Object.keys(v)) {
+      const item = plain(v[key], seen)
+      if (item === undefined && v[key] !== null) return undefined
+      out[key] = item
+    }
+    return out
+  }
+  return plain(value, new Set())
+}
+for (const [i, st] of jsonStates.entries()) {
+  const cloned = snapshotJsonValue(st)
+  assert.ok(cloned !== undefined, `state after event ${i + 1} is losslessly JSON-serializable (plain-JSON projection-cache precondition)`)
+  assert.deepEqual(cloned, JSON.parse(JSON.stringify(st)), `state after event ${i + 1} round-trips losslessly`)
+}
+// And the armed-but-unconsumed intermediate (compaction arm then replacement)
+// must also stay serializable.
+const armed = def.apply(def.init(), { seq: 1, type: 'compaction/summary', time: 1000, data: { shadowedSeqs: [2], shadowedTokenCount: 10 } })
+assert.ok(snapshotJsonValue(armed) !== undefined, 'armed pendingShadowedSeqs state is still plain JSON')
+
+console.log('✔ host half functional test passed (projection unit, fold semantics, attribution, retention, shadow-price seqs, reference stability, determinism, config bounds, inject pinning, model switch, usage mapping, plain-JSON state)')


### PR DESCRIPTION
## Problem

The `contextTimeline` fold state carried `undefined`-valued properties:
- `model`/`provider`/`lastModel`/`contextWindow` initialized to `undefined` in `createTimelineState()`
- `pendingShadowedSeqs` explicitly assigned `undefined` when consumed in `applySurface()`

The harness projection cache (`dsh-session-projection-cache`) checkpoints the **whole session** through a lossless-JSON snapshotter (`snapshotJsonValue` in `@deepseek-ai/dsh-session`) that **rejects any `undefined` property value**. Every cache write then failed with:

```
TypeError: projection checkpoint is not losslessly JSON-serializable (a unit state violates the plain-JSON contract)
```

Because the checkpoint is atomic per session, a single failing unit (this one) kept the **entire session cache stale** — including the `title` projection row that powers the session list after a restart. Symptom reported by users: after restarting the app, session names in the list show the cwd basename or raw session id until the session is opened (live fold) again.

Evidence from a real deployment (`dsh-2026-08-20.error.log`): **1426** `session projection cache: ... write failed ... not losslessly JSON-serializable` warnings starting exactly when `dsh-context@0.17.0` was installed; `session_projcache.json` stopped updating at that moment; all sessions created afterwards had no cached `title` row.

## Fix

- Optional fields (`model`/`provider`/`lastModel`/`contextWindow`) stay **absent** until a value is known, instead of `undefined`-valued. Reads via `state.model` are identical for both shapes (`undefined` on miss), so `buildTimelineView` is unchanged.
- `pendingShadowedSeqs` is **deleted** (not set to `undefined`) when consumed.
- `stateVersion` bumped **3 → 4** so stale cached rows (which may still contain `undefined`-valued properties from older folds) are discarded and refolded clean.

## Tests

Adds a host regression test that drives `init`/`apply` over the full live fixture plus an armed-then-consumed compaction sequence, and asserts **every intermediate state** survives the lossless-JSON snapshotter (plus a lossless round-trip). Verified the new test **fails on the old code** and passes with the fix; the full suite (typecheck + host + client + all UI tests) passes.

## Note on `contextHeaders`

The `schema: t` field in `contextHeaders` stores the raw tool object. In practice DSH's `request/header.tools` entries are plain JSON (`{name, description, parameters}`), so this is not currently a violation — left untouched to keep the diff minimal.