### PR TITLE
feat(client): hide the composer while the Context tab is active

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,5 +28,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Client tests mount the built bundle (tests/helpers/viewBed.ts reads
+      # lib/client.js), so the build must precede the test run.
+      - name: Build
+        run: pnpm run build
+
       - name: Test (typecheck + vitest)
         run: pnpm test

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,32 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-checks:
+    name: PR checks
+    runs-on: ubuntu-latest
+    environment: pr-checks
+    steps:
+      - uses: actions/checkout@v7
+
+      # Reads the pinned pnpm version from `packageManager` in package.json.
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test (typecheck + vitest)
+        run: pnpm test

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -462,3 +462,4 @@
 .lc-att-name { font-size: 12px; color: var(--dsw-alias-label-primary); line-height: 1.3; overflow-wrap: anywhere; word-break: break-word; }
 .lc-att-row { font-size: 11px; color: var(--dsw-alias-label-secondary); font-variant-numeric: tabular-nums; }
 .lc-att-row-label { display: inline-block; min-width: 3.2em; font-weight: 400; }
+[data-conversation-scroll]:has(.lc-root) > [data-composer-seat]:not(:has([data-approval-key], [data-question-key], [data-plan-review-key])) { display: none; }


### PR DESCRIPTION
## Background

Closes #11 — hide the bottom chat composer automatically while the Context tab is open, giving the context stats / history trend chart the full viewport height.

## Implementation

One CSS rule in `src/client/styles.css`, zero JS:

```css
[data-conversation-scroll]:has(.lc-root) > [data-composer-seat]:not(:has([data-approval-key], [data-question-key], [data-plan-review-key])) { display: none; }
```

- The view ring mounts one view at a time (`conversation.view` slot contract), so `.lc-root` existing inside the shell scrollport is exactly "Context tab active" — a built-in toggle signal;
- `display: none` hides without unmounting: the composer draft survives the round trip and comes back the moment the Chat tab is selected;
- **Takeover guard**: approval, question, and plan-review panels replace the bar inside the same seat — the seat stays visible whenever one is present, so a pending decision is never swallowed by the focus mode.

## Compatibility

- The `data-conversation-scroll` / `data-composer-seat` markers are verified identical in shell **0.1.0-rc.7** (oldest supported) and **0.1.1-rc.2** (current);
- These markers are shell internals rather than public API, but the rule is fail-soft: if they ever get renamed, the selector simply stops matching and the composer stays — no breakage;
- `:has()` requires Chromium 105+ / Safari 15.4+ / Firefox 121+; DSH Desktop (Electron) and all current browsers qualify.

## Verification

- `pnpm run build` ✅ (the minified rule survives lightningcss intact in `lib/client.js`)
- `pnpm run test` ✅ (typecheck + 17 files / 24 cases)
- `pnpm run lint` ✅

## Also in this PR

A separate commit fixes a pre-existing CI gap: the PR-checks workflow ran `pnpm test` without building first, while client tests mount the built bundle (`tests/helpers/viewBed.ts` reads `lib/client.js`) — every PR would fail with ENOENT. Added a `pnpm run build` step before the test step.