### PR TITLE
docs: add dshfind badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/dsh-context)](https://www.npmjs.com/package/dsh-context)
 [![GitHub stars](https://img.shields.io/github/stars/bowenliang123/dsh-context?style=social)](https://github.com/bowenliang123/dsh-context)
+[![dshfind](https://dshfind.com/api/badge/bowenliang123/dsh-context)](https://dshfind.com/en/plugins/bowenliang123/dsh-context?ref=badge)
 
 **The best [DeepSeek Harness plugin](https://www.deepseek.com/harness/) for Agent's context insights and management.**
 


### PR DESCRIPTION
`dsh-context` is listed on [dshfind](https://dshfind.com), a directory for DeepSeek Harness plugins, where it currently carries the **Featured** mark. This adds the listing badge to the README badge row, right after the GitHub stars badge.

Preview: [![dshfind](https://dshfind.com/api/badge/bowenliang123/dsh-context)](https://dshfind.com/en/plugins/bowenliang123/dsh-context?ref=badge)

One line changed, no other edits. Feel free to close if you'd rather not carry third-party badges — no hard feelings, the listing stays either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qj6wERPu4n2to3KmBXcVEz