### PR TITLE
fix(host): keep tool schemas plain-JSON in the contextHeaders projection

### DIFF
--- a/src/host/headers.ts
+++ b/src/host/headers.ts
@@ -25,6 +25,38 @@ import { estimateToolSchema } from './pricing'
 /** Retention cap on header epochs (changes are rare; 50 is generous). */
 const HEADERS_MAX = 50
 
+/**
+ * Detach one tool entry into a plain-JSON schema for the projection state.
+ *
+ * The projection-cache precondition is lossless JSON (`isJsonValue`): the
+ * raw header entries are `ToolDefinition`s that also carry the `execute`
+ * callback and other non-JSON fields, and materializing one into persisted
+ * state fails EVERY projection push for the session (`api-session/added`
+ * rejects the whole payload — sessions then fail to open). Only the JSON
+ * schema surface the model received is kept: scalars survive, functions and
+ * `undefined`-valued properties are dropped, and exotic objects degrade to
+ * their plain-JSON parts (an entry with nothing JSON-safe left becomes
+ * `undefined`, which the caller omits).
+ */
+export function jsonSchemaOf(value: unknown): unknown {
+  if (value === null) return null
+  const type = typeof value
+  if (type === 'string' || type === 'boolean') return value
+  if (type === 'number') return Number.isFinite(value) ? value : undefined
+  if (type !== 'object') return undefined
+  if (Array.isArray(value)) {
+    const items = value.map(jsonSchemaOf)
+    return items.every(item => item !== undefined) ? items : undefined
+  }
+  const record = value as Record<string, unknown>
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(record)) {
+    const clean = jsonSchemaOf(record[key])
+    if (clean !== undefined) out[key] = clean
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
 export interface HeadersState {
   headers: HeaderRecord[]
 }
@@ -65,10 +97,11 @@ function recordOf(event: SessionEvent): HeaderRecord | null {
       // The log is untrusted input: a null or primitive entry degrades to an
       // unnamed, JSON-priced tool instead of throwing the fold.
       const tool = (t !== null && typeof t === 'object' ? t : {}) as { name?: unknown; description?: unknown; plugin?: unknown }
+      const schema = jsonSchemaOf(t)
       const entry: HeaderTool = {
         name: typeof tool.name === 'string' ? tool.name : '?',
         tokens: estimateToolSchema(t),
-        schema: t,
+        ...(schema !== undefined ? { schema } : {}),
       }
       if (typeof tool.description === 'string' && tool.description !== '') {
         entry.description = tool.description

--- a/tests/host/headers.spec.ts
+++ b/tests/host/headers.spec.ts
@@ -228,4 +228,63 @@ describe('hostile tool entries', () => {
       assert.ok('schema' in tool, 'the raw schema rides the record')
     }
   })
+
+  test('a real ToolDefinition (with an execute callback) folds to a plain-JSON schema', () => {
+    const def = createContextHeadersDefinition()
+    const tool = {
+      name: 'bash',
+      description: 'Run shell commands',
+      parameters: { type: 'object', properties: { command: { type: 'string' } } },
+      output: { schema: { type: 'string' } },
+      execute: () => Promise.resolve('ok'), // non-JSON: must not ride the projection
+    }
+    const view = def.view(fold(def, [headerEvent(1, { tools: [tool] })]))
+    const folded = view.headers[0].tools[0]
+    assert.equal(folded.name, 'bash')
+    assert.equal(folded.description, 'Run shell commands')
+    assert.ok('schema' in folded, 'the JSON schema rides the record')
+    assert.ok(
+      !('execute' in (folded.schema as Record<string, unknown>)),
+      'execute never reaches the projection',
+    )
+    assert.deepEqual(
+      (folded.schema as { parameters: unknown }).parameters,
+      { type: 'object', properties: { command: { type: 'string' } } },
+      'the parameters schema survives',
+    )
+  })
+
+  test('non-finite numbers are dropped and function-only entries omit the schema key', () => {
+    const def = createContextHeadersDefinition()
+    const view = def.view(fold(def, [headerEvent(1, {
+      tools: [
+        { name: 'bad', parameters: { min: Number.NaN, max: 10 } },
+        { execute: () => undefined }, // no JSON-safe fields at all
+        { name: 'arr', parameters: { enum: ['a', () => 'x'] } }, // array with a function element
+        { name: 'empty', parameters: { enum: [] } }, // empty array keeps the schema
+      ],
+    })]))
+    const tools = view.headers[0].tools
+    assert.ok('schema' in tools[0], 'a schema with surviving fields rides the record')
+    assert.deepEqual(
+      tools[0].schema,
+      { name: 'bad', parameters: { max: 10 } },
+      'non-finite numbers are dropped, surviving fields stay',
+    )
+    assert.ok(!('schema' in tools[1]), 'a function-only entry omits the schema key')
+    assert.ok('schema' in tools[2], 'a surviving name keeps the schema')
+    assert.deepEqual(
+      tools[2].schema,
+      { name: 'arr' },
+      'a non-JSON array element drops that field, surviving fields stay',
+    )
+    assert.deepEqual(
+      tools[3].schema,
+      { name: 'empty', parameters: { enum: [] } },
+      'an empty array rides the schema',
+    )
+    assert.equal(tools[0].name, 'bad')
+    assert.equal(tools[1].name, '?')
+    assert.equal(tools[2].name, 'arr')
+  })
 })


### PR DESCRIPTION
The raw request-header tool entries are ToolDefinitions that also carry the execute callback and other non-JSON fields. Materializing one into the projection state broke every api-session/added push for the session (the harness rejects the whole payload as non-lossless JSON), so new sessions failed to open with 'argument 0 is not lossless JSON data'.

jsonSchemaOf() detaches each tool entry into its plain-JSON schema surface: scalars survive, functions and undefined-valued properties are dropped, exotic objects degrade to their JSON-safe parts, and an entry with nothing JSON-safe left omits the schema key.