### PR TITLE
fix(host): treat a cross-root relative as outside the plugin's own closure

### DIFF
--- a/src/host/version.ts
+++ b/src/host/version.ts
@@ -34,7 +34,7 @@
 
 import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { dirname, join, relative } from 'node:path'
+import { dirname, isAbsolute, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Context } from '@deepseek-ai/cordis'
 
@@ -146,7 +146,14 @@ function probeAnchor(resolve: Resolve, packageNames: readonly string[]): string 
  * would degrade to the home anchor, which is the safe direction.
  */
 function isInside(root: string, candidate: string): boolean {
-  return !relative(root, candidate).startsWith('..')
+  const rel = relative(root, candidate)
+  // `relative` answers with an ABSOLUTE path when the two sides share no root
+  // — on Windows that is any two drives, e.g. a probe home under C: and the
+  // plugin under E:. Such a path is no child of `root`, and reading it as one
+  // would discard every witness and drop the gate to the home anchor.
+  /* v8 ignore next -- Windows-only: a POSIX run cannot make `relative` cross a root. */
+  if (isAbsolute(rel)) return false
+  return !rel.startsWith('..')
 }
 
 /**


### PR DESCRIPTION
<!-- PR title: fix(host): treat a cross-root relative as outside the plugin's own closure -->
## What

Closes #59 — the Windows half of it. `isInside` read ownership from `path.relative` alone, treating any answer that does not start with `..` as a child of the plugin root. On Windows a probe home and the plugin commonly sit on different drives, where `relative` answers with an **absolute** path: every running-anchor witness then looked like the plugin's own dependency, the probe fell through to the home anchor, and a healthy desktop harness could still report the stale global CLI version — the upgrade modal on the first Context-tab open of every launch.

An absolute answer means the two sides share no root, so it is no child of `root`. The witness is discarded, and the mirror still answers for development setups.

## Highlights

- **One guard, at the seam the v0.49.4 fix left open** — `65e5f0e` moved the probe to the running module tree, but the ownership test it leans on misread every cross-drive witness, so the Windows case still landed on the mirror. This is the only place `relative` is consumed in that path; nothing else changes.
- **Development setups keep their fallback** — a `link:`-installed dev checkout still resolves through the profiles mirror, which is what it is for.
- **No POSIX behavior change** — no POSIX run can make `relative` cross a root, so the guard is marked Windows-only for coverage.

## Checks

- 1324 tests pass (81 files), per-file 100% coverage (statements / branches / functions / lines)
- `pnpm run lint` clean, `pnpm run build` clean
- **Reproduced and fixed on Windows.** `tests/host/version.spec.ts > never probes the CLI package from the running anchor` fails on the base revision and passes with this guard: the fixture's plugin root sits in the OS temp directory while the repository sits on another drive, which is the cross-root case exactly. A POSIX host has one root, so `relative` never crosses one there and the arm stays green — which is why it can sit unnoticed on `main` today.
- The guard is the Windows-only arm of the ownership test, so it carries the coverage exemption the POSIX suite cannot lift, with the reason recorded at the call site
